### PR TITLE
build(deps): Address vulnerabilities

### DIFF
--- a/docs/guides/go-built-in.md
+++ b/docs/guides/go-built-in.md
@@ -46,7 +46,7 @@ Verify that you have the latest version of Go installed (refer to the [official 
 
 ```bash
 $ go version
-go version go1.22.11 darwin/amd64
+go version go1.22.12 darwin/amd64
 ```
 
 ## 1.2 Creating a new Go project

--- a/docs/guides/go.md
+++ b/docs/guides/go.md
@@ -46,7 +46,7 @@ Verify that you have the latest version of Go installed (refer to the [official 
 
 ```bash
 $ go version
-go version go1.22.11 darwin/amd64
+go version go1.22.12 darwin/amd64
 ```
 
 ## 1.2 Creating a new Go project

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft
 
-go 1.22.11
+go 1.22.12
 
 require (
 	github.com/BurntSushi/toml v1.4.0
@@ -48,7 +48,6 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20220708102147-0a8a51822cae
-	github.com/supranational/blst v0.3.14
 	golang.org/x/sync v0.10.0
 	gonum.org/v1/gonum v0.15.1
 	google.golang.org/protobuf v1.36.4

--- a/go.sum
+++ b/go.sum
@@ -373,8 +373,6 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/supranational/blst v0.3.14 h1:xNMoHRJOTwMn63ip6qoWJ2Ymgvj7E2b9jY2FAwY+qRo=
-github.com/supranational/blst v0.3.14/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=


### PR DESCRIPTION
Vulnerability https://github.com/alesforz/cometbft/pull/2: GO-2025-3447
Timing sidechannel for P-256 on ppc64le in crypto/internal/nistec
More info: https://pkg.go.dev/vuln/GO-2025-3447
Standard library
Found in: crypto/internal/nistec@go1.23.5
Fixed in: crypto/internal/nistec@go1.23.6

This one https://pkg.go.dev/vuln/GO-2025-3487 is not fixed, because
1. It requires Go version upgrade, which we agreed we shouldn't do for security fixes (unless unavoidable)
2. The bug is in a part of the crypto library (ssh) which we don't use, hence it doesn't affect us.

This PR is not a cherry-pick because of the fundamental differences in versions.

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

