### PR TITLE
feat(state): RoundState includes blob fields

### DIFF
--- a/consensus/types/round_state.go
+++ b/consensus/types/round_state.go
@@ -101,12 +101,12 @@ type RoundState struct {
 	LastValidators            *types.ValidatorSet `json:"last_validators"`
 	TriggeredTimeoutPrecommit bool                `json:"triggered_timeout_precommit"`
 
-	ProposalBlob      *types.Blob    `json:"proposal_blob"`
+	ProposalBlob      types.Blob     `json:"proposal_blob"`
 	ProposalBlobParts *types.PartSet `json:"proposal_blob_parts"`
-	LockedBlob        *types.Blob    `json:"locked_blob"`
+	LockedBlob        types.Blob     `json:"locked_blob"`
 	LockedBlobParts   *types.PartSet `json:"locked_blob_parts"`
 	// Last known blob of POL mentioned above.
-	ValidBlob *types.Blob `json:"valid_blob"`
+	ValidBlob types.Blob `json:"valid_blob"`
 	// Last known blob parts of POL mentioned above.
 	ValidBlobParts *types.PartSet `json:"valid_blob_parts"`
 }

--- a/consensus/types/round_state.go
+++ b/consensus/types/round_state.go
@@ -141,6 +141,9 @@ func (rs *RoundState) RoundStateSimple() RoundStateSimple {
 		ProposalBlockHash: rs.ProposalBlock.Hash(),
 		LockedBlockHash:   rs.LockedBlock.Hash(),
 		ValidBlockHash:    rs.ValidBlock.Hash(),
+		ProposalBlobHash:  rs.ProposalBlob.Hash(),
+		LockedBlobHash:    rs.LockedBlob.Hash(),
+		ValidBlobHash:     rs.ValidBlob.Hash(),
 		Votes:             votesJSON,
 		Proposer: types.ValidatorInfo{
 			Address: addr,

--- a/consensus/types/round_state.go
+++ b/consensus/types/round_state.go
@@ -90,9 +90,9 @@ type RoundState struct {
 	//     response to `ProcessProposal`, or "Reject"
 
 	// Last known round with POL for non-nil valid block.
-	ValidRound int32        `json:"valid_round"`
-	ValidBlock *types.Block `json:"valid_block"` // Last known block of POL mentioned above.
-
+	ValidRound int32 `json:"valid_round"`
+	// Last known block of POL mentioned above.
+	ValidBlock *types.Block `json:"valid_block"`
 	// Last known block parts of POL mentioned above.
 	ValidBlockParts           *types.PartSet      `json:"valid_block_parts"`
 	Votes                     *HeightVoteSet      `json:"votes"`
@@ -100,6 +100,15 @@ type RoundState struct {
 	LastCommit                *types.VoteSet      `json:"last_commit"`  // Last precommits at Height-1
 	LastValidators            *types.ValidatorSet `json:"last_validators"`
 	TriggeredTimeoutPrecommit bool                `json:"triggered_timeout_precommit"`
+
+	ProposalBlob      *types.Blob    `json:"proposal_blob"`
+	ProposalBlobParts *types.PartSet `json:"proposal_blob_parts"`
+	LockedBlob        *types.Blob    `json:"locked_blob"`
+	LockedBlobParts   *types.PartSet `json:"locked_blob_parts"`
+	// Last known blob of POL mentioned above.
+	ValidBlob *types.Blob `json:"valid_blob"`
+	// Last known blob parts of POL mentioned above.
+	ValidBlobParts *types.PartSet `json:"valid_blob_parts"`
 }
 
 // Compressed version of the RoundState for use in RPC
@@ -111,6 +120,9 @@ type RoundStateSimple struct {
 	ValidBlockHash    bytes.HexBytes      `json:"valid_block_hash"`
 	Votes             json.RawMessage     `json:"height_vote_set"`
 	Proposer          types.ValidatorInfo `json:"proposer"`
+	ProposalBlobHash  bytes.HexBytes      `json:"proposal_blob_hash"`
+	LockedBlobHash    bytes.HexBytes      `json:"locked_blob_hash"`
+	ValidBlobHash     bytes.HexBytes      `json:"valid_blob_hash"`
 }
 
 // Compress the RoundState to RoundStateSimple

--- a/consensus/types/round_state.go
+++ b/consensus/types/round_state.go
@@ -208,10 +208,13 @@ func (rs *RoundState) StringIndented(indent string) string {
 %s  Validators:    %v
 %s  Proposal:      %v
 %s  ProposalBlock: %v %v
+%s  ProposalBlob:  %v %v
 %s  LockedRound:   %v
 %s  LockedBlock:   %v %v
+%s  LockedBlob:    %v %v
 %s  ValidRound:    %v
 %s  ValidBlock:    %v %v
+%s  ValidBlob:     %v %v
 %s  Votes:         %v
 %s  LastCommit:    %v
 %s  LastValidators:%v
@@ -222,10 +225,13 @@ func (rs *RoundState) StringIndented(indent string) string {
 		indent, rs.Validators.StringIndented(indent+"  "),
 		indent, rs.Proposal,
 		indent, rs.ProposalBlockParts.StringShort(), rs.ProposalBlock.StringShort(),
+		indent, rs.ProposalBlobParts.StringShort(), rs.ProposalBlob.String(),
 		indent, rs.LockedRound,
 		indent, rs.LockedBlockParts.StringShort(), rs.LockedBlock.StringShort(),
+		indent, rs.LockedBlobParts.StringShort(), rs.LockedBlob.String(),
 		indent, rs.ValidRound,
 		indent, rs.ValidBlockParts.StringShort(), rs.ValidBlock.StringShort(),
+		indent, rs.ValidBlobParts.StringShort(), rs.ValidBlob.String(),
 		indent, rs.Votes.StringIndented(indent+"  "),
 		indent, rs.LastCommit.StringShort(),
 		indent, rs.LastValidators.StringIndented(indent+"  "),

--- a/types/block.go
+++ b/types/block.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
@@ -56,6 +57,16 @@ const (
 // acts purely as a finalization gadget, so storing blobs in CometBFT's storage
 // layer is unnecessary and undesirable.
 type Blob []byte
+
+// Hash returns the SHA-256 hash of the blob.
+func (b Blob) Hash() []byte {
+	return tmhash.Sum(b)
+}
+
+// String returns a hex-encoded representation of the blob.
+func (b Blob) String() string {
+	return hex.EncodeToString(b)
+}
 
 // Block defines the atomic unit of a CometBFT blockchain.
 type Block struct {

--- a/types/block.go
+++ b/types/block.go
@@ -65,7 +65,10 @@ func (b Blob) Hash() []byte {
 
 // String returns a hex-encoded representation of the blob.
 func (b Blob) String() string {
-	return hex.EncodeToString(b)
+	if b == nil {
+		return "nil-Blob"
+	}
+	return "Blob#" + hex.EncodeToString(b)
 }
 
 // Block defines the atomic unit of a CometBFT blockchain.


### PR DESCRIPTION
Context

The RoundState is a data structure keeping track of the status of the consensus algorithm at the current height.
Because CometBFT will gossip blobs separately rather than including them into blocks, the RoundState must keep track of them during consensus rounds at any given height.
Changes

This PR updates the RoundState and RoundStateSimple data structures to include fields handling the blob during rounds of consensus.

Note: another PR will take care of updating these new RoundState fields during consensus.
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

