### PR TITLE
feat(state): `RoundState` does not need `Valid*` and `Locked*` blob fields.

### DIFF
--- a/consensus/types/round_state.go
+++ b/consensus/types/round_state.go
@@ -103,12 +103,6 @@ type RoundState struct {
 
 	ProposalBlob      types.Blob     `json:"proposal_blob"`
 	ProposalBlobParts *types.PartSet `json:"proposal_blob_parts"`
-	LockedBlob        types.Blob     `json:"locked_blob"`
-	LockedBlobParts   *types.PartSet `json:"locked_blob_parts"`
-	// Last known blob of POL mentioned above.
-	ValidBlob types.Blob `json:"valid_blob"`
-	// Last known blob parts of POL mentioned above.
-	ValidBlobParts *types.PartSet `json:"valid_blob_parts"`
 }
 
 // Compressed version of the RoundState for use in RPC
@@ -121,8 +115,6 @@ type RoundStateSimple struct {
 	Votes             json.RawMessage     `json:"height_vote_set"`
 	Proposer          types.ValidatorInfo `json:"proposer"`
 	ProposalBlobHash  bytes.HexBytes      `json:"proposal_blob_hash"`
-	LockedBlobHash    bytes.HexBytes      `json:"locked_blob_hash"`
-	ValidBlobHash     bytes.HexBytes      `json:"valid_blob_hash"`
 }
 
 // Compress the RoundState to RoundStateSimple
@@ -142,8 +134,6 @@ func (rs *RoundState) RoundStateSimple() RoundStateSimple {
 		LockedBlockHash:   rs.LockedBlock.Hash(),
 		ValidBlockHash:    rs.ValidBlock.Hash(),
 		ProposalBlobHash:  rs.ProposalBlob.Hash(),
-		LockedBlobHash:    rs.LockedBlob.Hash(),
-		ValidBlobHash:     rs.ValidBlob.Hash(),
 		Votes:             votesJSON,
 		Proposer: types.ValidatorInfo{
 			Address: addr,
@@ -217,10 +207,8 @@ func (rs *RoundState) StringIndented(indent string) string {
 %s  ProposalBlob:  %v %v
 %s  LockedRound:   %v
 %s  LockedBlock:   %v %v
-%s  LockedBlob:    %v %v
 %s  ValidRound:    %v
 %s  ValidBlock:    %v %v
-%s  ValidBlob:     %v %v
 %s  Votes:         %v
 %s  LastCommit:    %v
 %s  LastValidators:%v
@@ -234,10 +222,8 @@ func (rs *RoundState) StringIndented(indent string) string {
 		indent, rs.ProposalBlobParts.StringShort(), rs.ProposalBlob.String(),
 		indent, rs.LockedRound,
 		indent, rs.LockedBlockParts.StringShort(), rs.LockedBlock.StringShort(),
-		indent, rs.LockedBlobParts.StringShort(), rs.LockedBlob.String(),
 		indent, rs.ValidRound,
 		indent, rs.ValidBlockParts.StringShort(), rs.ValidBlock.StringShort(),
-		indent, rs.ValidBlobParts.StringShort(), rs.ValidBlob.String(),
 		indent, rs.Votes.StringIndented(indent+"  "),
 		indent, rs.LastCommit.StringShort(),
 		indent, rs.LastValidators.StringIndented(indent+"  "),


### PR DESCRIPTION
### Context
The RoundState is a data structure keeping track of the status of the consensus algorithm at the current height.
Because CometBFT will gossip blobs separately rather than including them into blocks, the RoundState must keep track of them during consensus rounds at any given height.

### Changes
This PR deletes the fields `ValidBlob`, `ValidBlobParts`, `LockedBlob`, and `LockedBlobParts` from the `RoundState` and `RoundStateSimple` data structures.

We initially added them in #5 but after further internal discussion, we decided they aren’t necessary. The rationale is that when a block is being re-proposed (`POLRound >= 0`), `ProcessProposal` is never called. As a result, we don’t need to store `ValidBlob` and `ValidBlobParts`. This works because when peers receive a re-proposed block with enough votes, they call `FinalizeBlock` directly, skipping `ProcessProposal`. And, since our solution does not provide the blob in `FinalizeBlock`, there’s no need to re-broadcast the blob of a re-proposed block.  You can see this behavior in the implementation of [`defaultDoPrevote`](https://github.com/alesforz/cometbft/blob/9b11ae49d95014a9f52d27c9eb25b8c9688dd57c/internal/consensus/state.go#L1513).

Note: another PR will take care of updating these new `RoundState` fields during consensus.