### PR TITLE
feat(state): Split `Blob` into blob parts and send it to internal message queue

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,6 +73,25 @@ linters-settings:
           - github.com/stretchr/testify/require
           - github.com/syndtr/goleveldb
           - github.com/decred/dcrd/dcrec/secp256k1/v4
+          - google.golang.org/protobuf/proto
+          - google.golang.org/protobuf/types/known/timestamppb
+          - golang.org/x/sync/errgroup
+          - golang.org/x/net/netutil
+          - golang.org/x/crypto/chacha20poly1305
+          - golang.org/x/net/netutil
+          - google.golang.org/grpc
+          - golang.org/x/net/context
+          - google.golang.org/grpc
+          - golang.org/x/crypto/openpgp/armor
+          - gonum.org/v1/gonum/stat
+          - golang.org/x/crypto/chacha20poly1305
+          - golang.org/x/crypto/curve25519
+          - golang.org/x/crypto/hkdf
+          - golang.org/x/crypto/nacl/box
+          - google.golang.org/grpc
+          - google.golang.org/grpc/credentials/insecure
+          - golang.org/x/crypto/nacl/secretbox
+          - golang.org/x/sync/semaphore
       test:
         files:
           - "$test"
@@ -94,6 +113,11 @@ linters-settings:
           - github.com/spf13
           - github.com/stretchr/testify
           - github.com/decred/dcrd/dcrec/secp256k1/v4
+          - google.golang.org/grpc
+          - golang.org/x/net/context
+          - golang.org/x/crypto/bcrypt
+          - golang.org/x/crypto/chacha20poly1305
+          - google.golang.org/protobuf/types/known/timestamppb
 
   revive:
     enable-all-rules: true

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -224,6 +224,7 @@ func startTestRound(cs *State, height int64, round int32) {
 	cs.startRoutines(0)
 }
 
+//nolint:unused
 func createProposalBlockWithTime(t *testing.T, cs *State, time time.Time) (*types.Block, *types.PartSet, types.BlockID) {
 	t.Helper()
 	block, _, err := cs.createProposalBlock(context.Background())
@@ -237,6 +238,7 @@ func createProposalBlockWithTime(t *testing.T, cs *State, time time.Time) (*type
 	return block, blockParts, blockID
 }
 
+//nolint:unused
 func createProposalBlock(t *testing.T, cs *State) (*types.Block, *types.PartSet, types.BlockID) {
 	t.Helper()
 	return createProposalBlockWithTime(t, cs, time.Time{})

--- a/consensus/msgs_test.go
+++ b/consensus/msgs_test.go
@@ -90,6 +90,7 @@ func TestMsgToProto(t *testing.T) {
 	)
 	pbVote := vote.ToProto()
 	pbBlobPart, err := blobPart.ToProto()
+	require.NoError(t, err)
 
 	testsCases := []struct {
 		testName string
@@ -437,14 +438,14 @@ func TestConsMsgsVectors(t *testing.T) {
 			"327b0a790802100122480a206164645f6d6f72655f6578636c616d6174696f6e5f6d61726b735f636f64652d1224080112206164645f6d6f72655f6578636c616d6174696f6e5f6d61726b735f636f64652d2a0608c0b89fdc0532146164645f6d6f72655f6578636c616d6174696f6e38014a09657874656e73696f6e"},
 		{
 			"Vote_with_nrp_ext", &cmtcons.Message{Sum: &cmtcons.Message_Vote{
-			Vote: &cmtcons.Vote{Vote: vextPbNonRp},
-		}},
+				Vote: &cmtcons.Vote{Vote: vextPbNonRp},
+			}},
 			"3281010a7f0802100122480a206164645f6d6f72655f6578636c616d6174696f6e5f6d61726b735f636f64652d1224080112206164645f6d6f72655f6578636c616d6174696f6e5f6d61726b735f636f64652d2a0608c0b89fdc0532146164645f6d6f72655f6578636c616d6174696f6e38014a09657874656e73696f6e5a0430783031",
 		},
 		{
 			"Vote_with_all_vote_ext", &cmtcons.Message{Sum: &cmtcons.Message_Vote{
-			Vote: &cmtcons.Vote{Vote: vextAllPb},
-		}},
+				Vote: &cmtcons.Vote{Vote: vextAllPb},
+			}},
 			"3281010a7f0802100122480a206164645f6d6f72655f6578636c616d6174696f6e5f6d61726b735f636f64652d1224080112206164645f6d6f72655f6578636c616d6174696f6e5f6d61726b735f636f64652d2a0608c0b89fdc0532146164645f6d6f72655f6578636c616d6174696f6e38014a09657874656e73696f6e5a0430783031",
 		},
 		{"HasVote", &cmtcons.Message{Sum: &cmtcons.Message_HasVote{

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1239,16 +1239,20 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 		cs.Logger.Error("failed flushing WAL to disk")
 	}
 
-	var propBlobID types.BlobID
+	var (
+		propBlobID types.BlobID
+		blobParts  *types.PartSet
+	)
+	// Not all blocks have a corresponding blob. If that's the case, we don't create
+	// blob parts and we don't set the blob ID.
 	if !blob.IsNil() {
-		blobParts := types.NewPartSetFromData(blob, types.BlobPartSizeBytes)
+		blobParts = types.NewPartSetFromData(blob, types.BlobPartSizeBytes)
 		propBlobID = types.BlobID{
 			Hash:          blob.Hash(),
 			PartSetHeader: blobParts.Header(),
 		}
 	}
 
-	// Make proposal
 	var (
 		propBlockID = types.BlockID{
 			Hash:          block.Hash(),
@@ -1266,7 +1270,7 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 	if err := cs.privValidator.SignProposal(cs.state.ChainID, p); err == nil {
 		proposal.Signature = p.Signature
 
-		// send proposal and block parts on internal msg queue
+		// send proposal, block parts, and blob parts on internal proposalMsg queue
 		cs.sendInternalMessage(msgInfo{&ProposalMessage{proposal}, ""})
 
 		for i := 0; i < int(blockParts.Total()); i++ {
@@ -1275,6 +1279,21 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 		}
 
 		cs.Logger.Debug("signed proposal", "height", height, "round", round, "proposal", proposal)
+		// Recall that not all blocks have a corresponding blob. Therefore, we might
+		// have not initialized the blobParts pointer a few lines above. Obviously,
+		// if blobParts is nil, we have nothing to send.
+		if blobParts != nil {
+			for i := range blobParts.Total() {
+				var (
+					part        = blobParts.GetPart(int(i))
+					blobPartMsg = msgInfo{
+						Msg:         &BlobPartMessage{cs.Height, cs.Round, part},
+						PeerID:      "",
+					}
+				)
+				cs.sendInternalMessage(blobPartMsg)
+			}
+		}
 	} else if !cs.replayMode {
 		cs.Logger.Error("propose step; failed signing proposal", "height", height, "round", round, "err", err)
 	}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1225,6 +1225,7 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 			panic("Method createProposalBlock should not provide a nil block without errors")
 		}
 		cs.metrics.ProposalCreateCount.Add(1)
+
 		blockParts, err = block.MakePartSet(types.BlockPartSizeBytes)
 		if err != nil {
 			cs.Logger.Error("unable to create proposal block part set", "error", err)
@@ -1238,11 +1239,17 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 		cs.Logger.Error("failed flushing WAL to disk")
 	}
 
-	// Make proposal
+	var propBlobID types.BlobID
+	if !blob.IsNil() {
+		blobParts := types.NewPartSetFromData(blob, types.BlobPartSizeBytes)
+		propBlobID = types.BlobID{
+			Hash:          blob.Hash(),
+			PartSetHeader: blobParts.Header(),
+		}
+	}
 
+	// Make proposal
 	var (
-		// TODO: create blob parts, BlobID, send blob parts.
-		_           = blob
 		propBlockID = types.BlockID{
 			Hash:          block.Hash(),
 			PartSetHeader: blockParts.Header(),
@@ -1252,7 +1259,7 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 			round,
 			cs.ValidRound,
 			propBlockID,
-			types.BlobID{}, // TODO: add part set
+			propBlobID,
 		)
 		p = proposal.ToProto()
 	)

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1287,8 +1287,8 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 				var (
 					part        = blobParts.GetPart(int(i))
 					blobPartMsg = msgInfo{
-						Msg:         &BlobPartMessage{cs.Height, cs.Round, part},
-						PeerID:      "",
+						Msg:    &BlobPartMessage{cs.Height, cs.Round, part},
+						PeerID: "",
 					}
 				)
 				cs.sendInternalMessage(blobPartMsg)

--- a/consensus/wal_test.go
+++ b/consensus/wal_test.go
@@ -3,10 +3,11 @@ package consensus
 import (
 	"bytes"
 	"crypto/rand"
-	"github.com/cometbft/cometbft/crypto/tmhash"
-	cmtrand "github.com/cometbft/cometbft/libs/rand"
 	"os"
 	"path/filepath"
+
+	"github.com/cometbft/cometbft/crypto/tmhash"
+	cmtrand "github.com/cometbft/cometbft/libs/rand"
 
 	// "sync"
 	"testing"
@@ -112,7 +113,7 @@ func TestWALEncoderDecoder(t *testing.T) {
 		{Time: now, Msg: msgInfo{Msg: &BlobPartMessage{
 			Height: 1,
 			Round:  1,
-			Part:   &cmttypes.Part{
+			Part: &cmttypes.Part{
 				Index: 1,
 				Bytes: []byte("blob"),
 				Proof: merkle.Proof{

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -1124,7 +1124,7 @@ func TestCreateProposalWithBlob(t *testing.T) {
 
 	var (
 		app          = &abcimocks.Application{}
-		proposalResp = &abci.PrepareProposalResponse{
+		proposalResp = &abci.ResponsePrepareProposal{
 			Blob: []byte("blob"),
 		}
 	)
@@ -1140,7 +1140,7 @@ func TestCreateProposalWithBlob(t *testing.T) {
 	defer proxyApp.Stop() //nolint:errcheck // ignore for tests
 
 	var (
-		state, stateDB, privVals = makeState(10, height, chainID)
+		state, stateDB, privVals = makeState(10, height)
 		storeOpts                = sm.StoreOptions{DiscardABCIResponses: false}
 		stateStore               = sm.NewStore(stateDB, storeOpts)
 		mp                       = &mpmocks.Mempool{}
@@ -1172,7 +1172,7 @@ func TestCreateProposalWithBlob(t *testing.T) {
 		)
 		proposerAddr, _ = state.Validators.GetByIndex(0)
 	)
-	commit, err := makeValidCommit(
+	commit, _, err := makeValidCommit(
 		height,
 		types.BlockID{},
 		state.Validators,

--- a/state/txindex/kv/kv_test.go
+++ b/state/txindex/kv/kv_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"testing"
 
 	"github.com/cosmos/gogoproto/proto"

--- a/state/txindex/kv/kv_test.go
+++ b/state/txindex/kv/kv_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"slices"
 	"testing"
 
 	"github.com/cosmos/gogoproto/proto"

--- a/types/params.go
+++ b/types/params.go
@@ -21,6 +21,15 @@ const (
 	// MaxBlockPartsCount is the maximum number of block parts.
 	MaxBlockPartsCount = (MaxBlockSizeBytes / BlockPartSizeBytes) + 1
 
+	// MaxBlobSyzeBytes is the maximum permitted size of a blob.
+	MaxBlobSizeBytes = 800 * 1024 // 800KB
+
+	// BlobPartSizeBytes is the size of one blob part.
+	BlobPartSizeBytes uint32 = 65536 // 64kB
+
+	// MaxBlobPartsCount defines the maximum number of blob parts.
+	MaxBlobPartsCount = (MaxBlobSizeBytes / BlobPartSizeBytes) + 1
+
 	ABCIPubKeyTypeEd25519   = ed25519.KeyType
 	ABCIPubKeyTypeSecp256k1 = secp256k1.KeyType
 )

--- a/types/params.go
+++ b/types/params.go
@@ -22,7 +22,7 @@ const (
 	MaxBlockPartsCount = (MaxBlockSizeBytes / BlockPartSizeBytes) + 1
 
 	// MaxBlobSyzeBytes is the maximum permitted size of a blob.
-	MaxBlobSizeBytes = 800 * 1024 // 800KB
+	MaxBlobSizeBytes = 800 * 1024 // 800kB
 
 	// BlobPartSizeBytes is the size of one blob part.
 	BlobPartSizeBytes uint32 = 65536 // 64kB

--- a/types/proposal_test.go
+++ b/types/proposal_test.go
@@ -18,8 +18,10 @@ import (
 var (
 	testProposal *Proposal
 	pbp          *cmtproto.Proposal
-	testBlockID  BlockID
-	testBlobID   BlobID
+	//nolint:unused
+	testBlockID BlockID
+	//nolint:unused
+	testBlobID BlobID
 )
 
 func init() {


### PR DESCRIPTION
### Context
A blob in a CometBFT blob's size can be between 128-800KB. To prevent sending big messages through the network, we want to split them into smaller ones and have peers reassemble the original message from its parts.

### Changes
This PR splits a non-nil blob into blob parts and sends them through the internal message queue so that the consensus state/reactor can process them. A blob part's size is at most 64KB. 

Note: the PR includes changes to unrelated files to address some complaints of the linter (i.e., they are not behavioral changes). The work relevant to this pr is in `internal/consensus/state.go` and `types/params.go`.